### PR TITLE
specify version in go install command for non-module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ brew install Code-Hex/tap/gqldoc
 Again, this tool is supported Go 1.16 and above. If you are one of those users, you can install like below.
 
 ```sh
-$ go install github.com/Code-Hex/gqldoc/cmd/gqldoc
+$ go install github.com/Code-Hex/gqldoc/cmd/gqldoc@latest
 ```
 
 ### Manually download


### PR DESCRIPTION
## WHAT

Specify `latest` on go install command.

## WHY

`go install` without `@version` fails when the current directory is not in a module. Specifying the version don't have any downsides, so it looks better to specify the version explicitly.

```shell
~  $ go install github.com/Code-Hex/gqldoc/cmd/gqldoc
go install: version is required when current directory is not in a module
        Try 'go install github.com/Code-Hex/gqldoc/cmd/gqldoc@latest' to install the latest version
```

ref: https://golang.org/ref/mod#go-install